### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -24,7 +24,7 @@ jobs:
               run: echo ${{ secrets.PRODUCTION_ENVIRONMENT_VARIABLES }} | base64 --decode > .env
 
             - name: Login, Build, Push Latest, Push Snapshot to DockerHub
-              uses: elgohr/Publish-Docker-Github-Action@master
+              uses: elgohr/Publish-Docker-Github-Action@v5
               with:
                   name: ${{ env.DOCKER_REPO_NAME }}
                   username: ${{ secrets.DOCKER_USERNAME }}

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -24,7 +24,7 @@ jobs:
               run: echo ${{ secrets.STAGING_ENVIRONMENT_VARIABLES }} | base64 --decode > .env
 
             - name: Login, Build, Push Latest, Push Snapshot to DockerHub
-              uses: elgohr/Publish-Docker-Github-Action@master
+              uses: elgohr/Publish-Docker-Github-Action@v5
               with:
                   name: ${{ env.DOCKER_REPO_NAME }}
                   username: ${{ secrets.DOCKER_USERNAME }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore